### PR TITLE
dev/cleanup_code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,29 @@
+---
+# options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+BasedOnStyle: LLVM
+
+IndentWidth: 4
+
+# Must be 100 characters or less!
+ColumnLimit: 100
+
+# does (int) x instead of (int)x
+SpaceAfterCStyleCast: true
+
+# spaces, not tabs!
+UseTab: Never
+# if (x) doStuff()  is not allowed, bad style
+AllowShortIfStatementsOnASingleLine: false
+
+AlignTrailingComments: true
+SpacesBeforeTrailingComments: 3
+
+#  #define SHORT_NAME       42
+#  #define LONGER_NAME      0x007f   # does nice spacing for macros
+AlignConsecutiveMacros: Consecutive
+
+# Specify placement of braces (if/else/while/for/...)
+BreakBeforeBraces: Allman
+
+# Force break after template delectation so that it is above the deceleration not next to it.
+AlwaysBreakTemplateDeclarations: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ROS NODE TYPE
 
 ## Overview
----
 ROS NODE TYPE is a ROS package which contains a cpp library intended to simplify the implementation of ROS subscribers. The goal was to automate the mundane task of creating callback functions for every ROS topic that needs subscribing to. The MySubscriber class takes care of creating callback functions and returns the last ROS message published. The class also has the ability to determine and discard a message that is stale. This makes "synchronizing" messages possible.
 <br>
 <br>
@@ -9,7 +8,6 @@ ROS NODE TYPE is a ROS package which contains a cpp library intended to simplify
 For some additional documentation regarding the package, you can check out this [README.md](./docs/README.md) file to get started.
 
 ## Dependencies
----
 - Doxygen:
     - Used to generate helpful documentation about library. 
     - For some info on how to get started with Doxygen, you can read this [README.md](./docs/README.md) file to get started.
@@ -19,7 +17,6 @@ For some additional documentation regarding the package, you can check out this 
 ***Note**: You can modify the [CMakeLists.txt](./CMakeLists.txt), located at the top level of this repo, to remove Doxygen. 
 
 ## Example
----
 The [MySubscriber_node.cpp](./src/MySubscriber_node.cpp) utilizes the library to subscribe to two ROS topics and returns the most recent messages.
 <br>
 
@@ -43,5 +40,4 @@ To run the example use the following steps:
    ```
 
 ## Author & Maintaner
----
 Julian Rendon

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,10 @@
 # **DOXYGEN NOTES**
 
 ### Documentation
----
 All documentation regarding doxygen can be found [here](https://www.doxygen.nl/manual/index.html). This includes download/installation of doxygen, how to modify doxygen configuration files to customize documentation, etc.
 
 ### Setting up Doxygen for CMake
----
 Instructions on how to setup doxygen for cmake can be found [here](https://vicrucann.github.io/tutorials/quick-cmake-doxygen/). <mark>This is only used as a template and should be modified for YOUR specific repository structure.</mark> Take a look at the [CMakelists.txt](../CMakeLists.txt) and [Doxyfile.in](./Doxyfile.in) located inside this repo to see how it was setup.
 
 ### Viewing Documenation
----
 You can view the documents by navigating to the ***docs/html/*** directory, located in this repository, and opening the index.html file on a web browser.

--- a/launch/MySubscriber_example.launch
+++ b/launch/MySubscriber_example.launch
@@ -1,6 +1,5 @@
 <!-- Example to show how the MySubscriber class works. -->
 <launch>
-    <node pkg="ros_node_type" type="name_pub" name="name_pub_node" />
     <node pkg="ros_node_type" type="number_pub" name="number_pub_node" />
     <node pkg="ros_node_type" type="MySubscriber" name="MySubscriber_node" output="screen" />
 </launch>

--- a/src/MySubscriber_node.cpp
+++ b/src/MySubscriber_node.cpp
@@ -2,13 +2,17 @@
  * @file MySubscriber_node.cpp
  * @author Julian Rendon (julianrendon514@gmail.com)
  * @brief Simple ROS subscriber node that utilizes the ros_node_pkg library.
- * @version 0.1
+ * @version 1.0
  * @date 2022-11-11
  *
  * ROS subscriber node that implements MySubscriber class to generate subscriber of any data type.
- * Creates two subscribers and receives their most recent ROS message.
  *
- * @copyright
+ * Creates a subscriber to the ROS topic "/number" of data type std_msgs::Int32. A message is
+ * received every 5 seconds however, because the timeout is set to 3 seconds, the message will be
+ * considered stale once that timeout is reached and NULL will be returned.
+ *
+ *
+ * @copyright Copyright (c) 2022
  *
  */
 
@@ -18,35 +22,28 @@
 #include <std_msgs/Int32.h>
 #include <std_msgs/String.h>
 
+// Message is considered stale after time elapsed exceeds timeout. (s)
+#define TIMEOUT 3
+
 int main(int argc, char **argv)
 {
     ros::init(argc, argv, "MySubscriber_node");
-
-    // Subscribe to topics.
+    // Subscriber.
     MySubscriber<std_msgs::Int32> num_sub("/number", 1);
-    MySubscriber<std_msgs::String> str_sub("/name", 1);
 
     while (ros::ok())
     {
-        // Timeout set to -1 so that we keep the last message.
-        auto num_msg = num_sub.get_msg(-1);
-        auto str_msg = str_sub.get_msg(-1);
+        // Get most recent message.
+        // Once time elapsed exceeds timeout, NULL will be returned.
+        auto num_msg = num_sub.get_msg(TIMEOUT);
 
-        if (str_msg == NULL && num_msg == NULL)
+        if (num_msg == NULL)
         {
-            ROS_INFO("Incoming messages: [NULL] [NULL]");
-        }
-        else if (num_msg != NULL && str_msg == NULL)
-        {
-            ROS_INFO("Incoming messages: [NULL], [%d].", num_msg->data);
-        }
-        else if (str_msg != NULL && num_msg == NULL)
-        {
-            ROS_INFO("Incoming messages: [%s], [NULL].", str_msg->data.c_str());
+            ROS_INFO("Timestamp[%.0f]: [NULL]", ros::Time::now().toSec());
         }
         else
         {
-            ROS_INFO("Incoming messages: [%s], [%d]", str_msg->data.c_str(), num_msg->data);
+            ROS_INFO("Timestamp:[%.0f], counter:[%d]", ros::Time::now().toSec(), num_msg->data);
         }
         ros::spinOnce();
     }

--- a/src/name_pub_node.cpp
+++ b/src/name_pub_node.cpp
@@ -2,7 +2,7 @@
  * @file name_pub_node.cpp
  * @author Julian Rendon (julianrendon514@gmail.com)
  * @brief Simple ROS publisher.
- * @version 0.1
+ * @version 1.0
  * @date 2022-11-12
  *
  * Publishes to /name ROS topic at a rate of 1 message per 5 seconds. Names are cycled once all
@@ -24,7 +24,7 @@ int main(int argc, char **argv)
     // Initialize publishers
     ros::Publisher name_pub = nh.advertise<std_msgs::String>("/name", 1);
 
-    // 1 messages every 5 seconds.
+    // 1 messages every 5 seconds. (Hz)
     ros::Rate loop(.20);
 
     // Names in alphabetical order.

--- a/src/number_pub_node.cpp
+++ b/src/number_pub_node.cpp
@@ -2,7 +2,7 @@
  * @file number_pub_node.cpp
  * @author Julian Rendon (julianrendon514@gmail.com)
  * @brief Simple ROS publisher.
- * @version 0.1
+ * @version 1.0
  * @date 2022-11-14
  *
  * Publishes to the /number ROS topic at a rate of 1 message per second. Message starts at 0 and
@@ -19,8 +19,13 @@ int main(int argc, char **argv)
 {
     ros::init(argc, argv, "number_pub_node");
     ros::NodeHandle nh;
+
+    // Initialize Publisher.
     ros::Publisher number_pub = nh.advertise<std_msgs::Int32>("/number", 1);
-    ros::Rate loop(1);
+
+    // 1 message every 5 seconds. (Hz)
+    ros::Rate loop(.20);
+
     int number_start = 0;
     while (ros::ok())
     {


### PR DESCRIPTION
### Overview
Logic for the `MySubscriber` class needed to be cleaned up. Also need to include clang formatting to keep code formatted properly.

### Major Changes
- Modified `ros_node_type.h` logic and cleaned up code to make it a bit more readable.
- Modified `MySubscriber_node.cpp`, `name_pub_node.cpp`, `number_pub_node.cpp` and `MySubscriber_example.launch` files to make the examples a bit clearer.
- Included `.clang-format` file to keep code formatted properly.

### Minor Changes
- Minor changes to the appearance of the `README.md` files.

### Action Item(s)
N/A